### PR TITLE
Set prompt using double quotes

### DIFF
--- a/lambda-mod.zsh-theme
+++ b/lambda-mod.zsh-theme
@@ -28,12 +28,12 @@ function get_right_prompt() {
     fi
 }
 
-PROMPT='
+PROMPT="
 ${LAMBDA}\
  %{$fg_bold[$USERCOLOR]%}%n\
  %{$fg_no_bold[magenta]%}[%3~]\
  $(check_git_prompt_info)\
-%{$reset_color%}'
+%{$reset_color%}"
 
 RPROMPT='$(get_right_prompt)'
 


### PR DESCRIPTION
Fixes #5 in gnome-terminal.

With this change `echo $PROMPT` produces `%(?,%{%}λ,%{%}λ) %{%}%n %{%}[%3~] %{%}→ %{%}`. Otherwise, with the existing single quotes substitution is deferred:

```
${LAMBDA}\
 %{$fg_bold[$USERCOLOR]%}%n\
 %{$fg_no_bold[magenta]%}[%3~]\
 $(check_git_prompt_info)\
%{$reset_color%}
```

The substitution delay explains why several have confirmed the workaround of removing `local` before `LAMBDA`'s assignment fixes it. I'm not sure why some terminals behave differently, but this fix will likely be portable and unobtrusive.