### PR TITLE
Added possibility of spawning a new line char

### DIFF
--- a/lambda-mod.zsh-theme
+++ b/lambda-mod.zsh-theme
@@ -1,5 +1,10 @@
 #!/usr/bin/env zsh
 
+# New Line Character
+NEW_LINE='
+'
+LAMBDA_NEW_LINE=${LAMBDA_NEW_LINE:-NEW_LINE}
+
 local LAMBDA="%(?,%{$fg_bold[green]%}λ,%{$fg_bold[red]%}λ)"
 if [[ "$USER" == "root" ]]; then USERCOLOR="red"; else USERCOLOR="yellow"; fi
 
@@ -32,6 +37,7 @@ PROMPT="
 ${LAMBDA}\
  %{$fg_bold[$USERCOLOR]%}%n\
  %{$fg_no_bold[magenta]%}[%3~]\
+ ${LAMBDA_NEW_LINE}\
  $(check_git_prompt_info)\
 %{$reset_color%}"
 


### PR DESCRIPTION
Sometimes folders grow very big in size and it becomes complicated to manage without a newline character.

I've added a variable so the user can set in the `.zshrc` file a new variable called `LAMBDA_NEW_LINE` to whatever he wants. If not set then the prompt will spawn a new line before the arrow:

![](http://i.imgur.com/HKJs0oz.png)