### PR TITLE
Make dir levels shown in the prompt configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ A ZSH theme optimized for people who use:
 ---
 
 ![Screenshot](https://raw.githubusercontent.com/halfo/lambda-mod-zsh-theme/master/screenshot.png)
+
+## Configuring the amount of dir levels
+
+By default only the last three directories are shown in the prompt. The amount of
+levels can be configured by setting `LAMBDA_MOD_N_DIR_LEVELS` before loading the prompt:
+
+``` zsh
+# ~/.zshrc
+export LAMBDA_MOD_N_DIR_LEVELS=10
+
+# load `lambda-mod` and `oh-my-zsh`
+```

--- a/lambda-mod.zsh-theme
+++ b/lambda-mod.zsh-theme
@@ -30,7 +30,7 @@ function get_right_prompt() {
 
 PROMPT=$'\n'$LAMBDA'\
  %{$fg_bold[$USERCOLOR]%}%n\
- %{$fg_no_bold[magenta]%}[%3~]\
+ %{$fg_no_bold[magenta]%}[%'${LAMBDA_MOD_N_DIR_LEVELS:-3}'~]\
  $(check_git_prompt_info)\
 %{$reset_color%}'
 


### PR DESCRIPTION
Until now the prompt only shows the last three levels of the prompt,
however I'd personally prefer to have some more levels (i.e. five).

I figured that it's not worth debating about how many levels make sense,
instead it's now configurable in `~/.zshrc`, the current default will be
kept.

This can be achieved by adding the following line to `~/.zshrc` *before*
loading this theme:

```
export LAMBDA_MOD_N_DIR_LEVELS=5
```