### PR TITLE
Allow optional host suffix on prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Lambda (Mod) ZSH Theme
 
 A ZSH theme optimized for people who use:
+
 - Git
 - Unicode-compatible fonts and terminals
 
@@ -10,12 +11,21 @@ A ZSH theme optimized for people who use:
 
 ## Configuring the amount of dir levels
 
-By default only the last three directories are shown in the prompt. The amount of
-levels can be configured by setting `LAMBDA_MOD_N_DIR_LEVELS` before loading the prompt:
+By default only the last three directories are shown in the prompt. The amount of levels can be
+configured by setting `LAMBDA_MOD_N_DIR_LEVELS` before loading the prompt:
 
-``` zsh
+```zsh
 # ~/.zshrc
 export LAMBDA_MOD_N_DIR_LEVELS=10
+
+# load `lambda-mod` and `oh-my-zsh`
+```
+
+You can display the hostname after the username with a "@" separator by setting:
+
+```zsh
+# ~/.zshrc
+export LAMBDA_MOD_HOST_SUF=true
 
 # load `lambda-mod` and `oh-my-zsh`
 ```

--- a/lambda-mod.zsh-theme
+++ b/lambda-mod.zsh-theme
@@ -7,29 +7,31 @@ if [[ "$USER" == "root" ]]; then USERCOLOR="red"; else USERCOLOR="yellow"; fi
 # return anything in this case. So wrap it in another function and check
 # for an empty string.
 function check_git_prompt_info() {
-    if type git &>/dev/null && git rev-parse --git-dir > /dev/null 2>&1; then
-        if [[ -z $(git_prompt_info 2> /dev/null) ]]; then
-            echo "%{$fg[blue]%}detached-head%{$reset_color%}) $(git_prompt_status)
+  if type git &>/dev/null && git rev-parse --git-dir >/dev/null 2>&1; then
+    if [[ -z $(git_prompt_info 2>/dev/null) ]]; then
+      echo "%{$fg[blue]%}detached-head%{$reset_color%}) $(git_prompt_status)
 %{$fg[yellow]%}→ "
-        else
-            echo "$(git_prompt_info 2> /dev/null) $(git_prompt_status)
-%{$fg_bold[cyan]%}→ "
-        fi
     else
-        echo "%{$fg_bold[cyan]%}→ "
+      echo "$(git_prompt_info 2>/dev/null) $(git_prompt_status)
+%{$fg_bold[cyan]%}→ "
     fi
+  else
+    echo "%{$fg_bold[cyan]%}→ "
+  fi
 }
 
 function get_right_prompt() {
-    if type git &>/dev/null && git rev-parse --git-dir > /dev/null 2>&1; then
-        echo -n "$(git_prompt_short_sha)%{$reset_color%}"
-    else
-        echo -n "%{$reset_color%}"
-    fi
+  if type git &>/dev/null && git rev-parse --git-dir >/dev/null 2>&1; then
+    echo -n "$(git_prompt_short_sha)%{$reset_color%}"
+  else
+    echo -n "%{$reset_color%}"
+  fi
 }
 
+HOST_SUF=$([[ "$LAMBDA_MOD_HOST_SUF" == "true" ]] && echo "@%m" || echo "")
+
 PROMPT=$'\n'$LAMBDA'\
- %{$fg_bold[$USERCOLOR]%}%n\
+ %{$fg_bold[$USERCOLOR]%}%n@'${HOST_SUF}'\
  %{$fg_no_bold[magenta]%}[%'${LAMBDA_MOD_N_DIR_LEVELS:-3}'~]\
  $(check_git_prompt_info)\
 %{$reset_color%}'
@@ -52,7 +54,6 @@ ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg_bold[cyan]%}?"
 
 # Format for git_prompt_ahead()
 ZSH_THEME_GIT_PROMPT_AHEAD=" %{$fg_bold[white]%}^"
-
 
 # Format for git_prompt_long_sha() and git_prompt_short_sha()
 ZSH_THEME_GIT_PROMPT_SHA_BEFORE=" %{$fg_bold[white]%}[%{$fg_bold[blue]%}"

--- a/lambda-mod.zsh-theme
+++ b/lambda-mod.zsh-theme
@@ -31,7 +31,7 @@ function get_right_prompt() {
 HOST_SUF=$([[ "$LAMBDA_MOD_HOST_SUF" == "true" ]] && echo "@%m" || echo "")
 
 PROMPT=$'\n'$LAMBDA'\
- %{$fg_bold[$USERCOLOR]%}%n@'${HOST_SUF}'\
+ %{$fg_bold[$USERCOLOR]%}%n'${HOST_SUF}'\
  %{$fg_no_bold[magenta]%}[%'${LAMBDA_MOD_N_DIR_LEVELS:-3}'~]\
  $(check_git_prompt_info)\
 %{$reset_color%}'


### PR DESCRIPTION
Adds `LAMBDA_MOD_HOST_SUF` env var to add `$(hostname)` to prompt

Also ran an auto formatter on the file, I can create a new PR with minimal changes if that isn't to your liking